### PR TITLE
Add tool import/export, deletion, and persistent settings

### DIFF
--- a/src/screens/ChatScreen.tsx
+++ b/src/screens/ChatScreen.tsx
@@ -9,6 +9,15 @@ export default function ChatScreen() {
   const [, navigate] = useLocation()
   const [input, setInput] = useState('')
   const bottomRef = useRef<HTMLDivElement>(null)
+  const [dialog, setDialog] = useState<{ mode: 'export' | 'import'; text: string } | null>(null)
+  const textareaRef = useRef<HTMLTextAreaElement>(null)
+
+  useEffect(() => {
+    if (dialog) {
+      textareaRef.current?.focus()
+      if (dialog.mode === 'export') textareaRef.current?.select()
+    }
+  }, [dialog])
 
   useEffect(() => {
     load()
@@ -114,51 +123,124 @@ export default function ChatScreen() {
   }
 
   return (
-    <main class="container" style="display: flex; gap: 1rem; align-items: flex-start;">
-      <div style="flex: 1; overflow-y: auto; max-height: 80vh;">
-        {messages.map((m) => (
-          <p>
-            {m.role === 'user' && `👨 ${m.content}`}
-            {m.role === 'assistant' && `🤖 ${m.content}`}
-            {m.role === 'tool' && (
-              <em>
-                🤖👉🔧 {m.toolName} {JSON.stringify(m.args)}{' '}
-                {m.result !== undefined && `=> ${JSON.stringify(m.result)}`}
-              </em>
-            )}
-          </p>
-        ))}
-        <div ref={bottomRef} />
-      </div>
-      <aside style="width: 300px;">
-        <h3>Tools</h3>
-        {tools.map((t) => (
-          <div>
-            <input
-              type="checkbox"
-              checked={!t.disabled}
-              onChange={() => useAppStore.getState().updateTool({ ...t, disabled: !t.disabled })}
-            />{' '}
-            {t.name}
+    <>
+      <main class="container" style="display: flex; gap: 1rem; align-items: flex-start;">
+        <div style="flex: 1; overflow-y: auto; max-height: 80vh;">
+          {messages.map((m) => (
+            <p>
+              {m.role === 'user' && `👨 ${m.content}`}
+              {m.role === 'assistant' && `🤖 ${m.content}`}
+              {m.role === 'tool' && (
+                <em>
+                  🤖👉🔧 {m.toolName} {JSON.stringify(m.args)}{' '}
+                  {m.result !== undefined && `=> ${JSON.stringify(m.result)}`}
+                </em>
+              )}
+            </p>
+          ))}
+          <div ref={bottomRef} />
+        </div>
+        <aside style="width: 300px;">
+          <h3>Tools</h3>
+          {tools.map((t) => (
+            <div>
+              <input
+                type="checkbox"
+                checked={!t.disabled}
+                onChange={() => useAppStore.getState().updateTool({ ...t, disabled: !t.disabled })}
+              />{' '}
+              {t.name}{' '}
+              <button
+                onClick={() => useAppStore.getState().removeTool(t.id)}
+                aria-label={`Delete ${t.name}`}
+              >
+                ✖
+              </button>
+            </div>
+          ))}
+          <button onClick={onAddTool}>Add Tool</button>
+          <button
+            onClick={() => setDialog({ mode: 'export', text: JSON.stringify(tools, null, 2) })}
+            style="margin-left: 0.5rem;"
+          >
+            Export
+          </button>
+          <button
+            onClick={() => {
+              if (!confirm('Import will overwrite existing tools. Continue?')) return
+              setDialog({ mode: 'import', text: '' })
+            }}
+            style="margin-left: 0.5rem;"
+          >
+            Import
+          </button>
+          <hr />
+          <button onClick={() => resetChat()}>Reset Chat</button>
+          <button onClick={() => clearTools()}>Clear All Tools</button>
+          <hr />
+          <button onClick={() => navigate('/settings')}>Settings</button>
+        </aside>
+        <div style="position: fixed; bottom: 1rem; left: 1rem; right: 320px;">
+          <input
+            style="width: 100%;"
+            value={input}
+            onInput={(e) => setInput((e.target as HTMLInputElement).value)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') sendMessage()
+            }}
+          />
+        </div>
+      </main>
+      {dialog && (
+        <div style="position: fixed; inset: 0; background: rgba(0,0,0,0.5); display: flex; align-items: center; justify-content: center;">
+          <div style="background: white; padding: 1rem; width: 90%; max-width: 500px;">
+            <textarea
+              ref={textareaRef}
+              style="width: 100%; height: 200px;"
+              value={dialog.text}
+              readOnly={dialog.mode === 'export'}
+              onInput={
+                dialog.mode === 'import'
+                  ? (e) =>
+                      setDialog({
+                        ...dialog,
+                        text: (e.target as HTMLTextAreaElement).value,
+                      })
+                  : undefined
+              }
+            />
+            <div style="margin-top: 0.5rem; text-align: right;">
+              {dialog.mode === 'import' ? (
+                <button
+                  onClick={async () => {
+                    try {
+                      const parsed = JSON.parse(dialog.text) as ToolDefinition[]
+                      await useAppStore.getState().setTools(parsed)
+                      setDialog(null)
+                    } catch {
+                      alert('Invalid JSON')
+                    }
+                  }}
+                >
+                  Import
+                </button>
+              ) : (
+                <button
+                  onClick={() => {
+                    navigator.clipboard?.writeText(dialog.text)
+                    setDialog(null)
+                  }}
+                >
+                  Copy
+                </button>
+              )}
+              <button onClick={() => setDialog(null)} style="margin-left: 0.5rem;">
+                Close
+              </button>
+            </div>
           </div>
-        ))}
-        <button onClick={onAddTool}>Add Tool</button>
-        <hr />
-        <button onClick={() => resetChat()}>Reset Chat</button>
-        <button onClick={() => clearTools()}>Clear All Tools</button>
-        <hr />
-        <button onClick={() => navigate('/settings')}>Settings</button>
-      </aside>
-      <div style="position: fixed; bottom: 1rem; left: 1rem; right: 320px;">
-        <input
-          style="width: 100%;"
-          value={input}
-          onInput={(e) => setInput((e.target as HTMLInputElement).value)}
-          onKeyDown={(e) => {
-            if (e.key === 'Enter') sendMessage()
-          }}
-        />
-      </div>
-    </main>
+        </div>
+      )}
+    </>
   )
 }

--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'preact/hooks'
+import { useEffect, useState } from 'preact/hooks'
 import Joi from 'joi'
 import { useLocation } from 'wouter-preact'
 import { useAppStore } from '../store'
@@ -17,6 +17,20 @@ export default function SettingsScreen() {
   const [error, setError] = useState<string>()
   const [, navigate] = useLocation()
   const setSettings = useAppStore((s) => s.setSettings)
+  const settings = useAppStore((s) => s.settings)
+  const load = useAppStore((s) => s.load)
+
+  useEffect(() => {
+    load()
+  }, [load])
+
+  useEffect(() => {
+    if (settings) {
+      setUrl(settings.apiBaseUrl)
+      setToken(settings.apiToken ?? '')
+      setModel(settings.model)
+    }
+  }, [settings])
 
   const onSubmit = async (e: Event) => {
     e.preventDefault()

--- a/src/store.test.ts
+++ b/src/store.test.ts
@@ -29,4 +29,35 @@ describe('store', () => {
     })
     expect(useAppStore.getState().tools).toHaveLength(1)
   })
+
+  it('removes tools', async () => {
+    await useAppStore.getState().addTool({
+      id: '1',
+      name: 't',
+      description: '',
+      args: [],
+      returnType: 'string',
+      returnValue: 'ok',
+      disabled: false,
+      createdAt: 1,
+    })
+    await useAppStore.getState().removeTool('1')
+    expect(useAppStore.getState().tools).toHaveLength(0)
+  })
+
+  it('sets tools list', async () => {
+    await useAppStore.getState().setTools([
+      {
+        id: '1',
+        name: 't',
+        description: '',
+        args: [],
+        returnType: 'string',
+        returnValue: 'ok',
+        disabled: false,
+        createdAt: 1,
+      },
+    ])
+    expect(useAppStore.getState().tools).toHaveLength(1)
+  })
 })

--- a/src/store.ts
+++ b/src/store.ts
@@ -14,6 +14,7 @@ interface AppState {
   addMessage: (m: ChatMessage) => Promise<void>
   addTool: (t: ToolDefinition) => Promise<void>
   updateTool: (t: ToolDefinition) => Promise<void>
+  setTools: (ts: ToolDefinition[]) => Promise<void>
   removeTool: (id: string) => Promise<void>
   resetChat: () => Promise<void>
   clearTools: () => Promise<void>
@@ -42,6 +43,10 @@ export const useAppStore = create<AppState>((set, get) => ({
     const tools = get().tools.map((tool) => (tool.id === t.id ? t : tool))
     await localforage.setItem(TOOLS_KEY, tools)
     set({ tools })
+  },
+  async setTools(ts) {
+    await localforage.setItem(TOOLS_KEY, ts)
+    set({ tools: ts })
   },
   async removeTool(id) {
     const tools = get().tools.filter((t) => t.id !== id)


### PR DESCRIPTION
## Summary
- enable replacing tools in store for import/export support
- allow deleting individual tools and importing/exporting tool configurations
- load saved settings into settings form when revisiting
- replace alert/prompt dialogs with a reusable textarea modal for import/export

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_6897617b4bd88329959d1e877deb9417