### PR TITLE
Handle API errors in chat and improve layout

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -24,10 +24,15 @@ a:hover {
 
 body {
   margin: 0;
-  display: grid;
-  place-items: center;
   min-width: 320px;
   min-height: 100vh;
+}
+
+#app {
+  width: 100%;
+  height: 100vh;
+  box-sizing: border-box;
+  padding: 1rem;
 }
 
 h1 {

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,6 +7,7 @@ export type Settings = {
 export type ChatMessage =
   | { role: 'user'; content: string; createdAt: number }
   | { role: 'assistant'; content: string; createdAt: number }
+  | { role: 'error'; content: string; createdAt: number }
   | {
       role: 'tool'
       toolName: string


### PR DESCRIPTION
## Summary
- Display API and network errors in chat with a `❌ API:` prefix using a dedicated `error` message role
- Exclude error messages from the request payload so they don't pollute the LLM context
- Expand chat layout so the conversation takes ~70% width and the tool panel sticks to the right with a minimum width

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_689768409bc483298796d296227248ba