### PR TITLE
Handle base URL for subdirectory deployments

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -12,8 +12,10 @@ export function App() {
     load()
   }, [load])
 
+  const base = import.meta.env.BASE_URL.replace(/\/$/, '')
+
   return (
-    <Router>
+    <Router base={base}>
       <Switch>
         <Route path="/settings" component={SettingsScreen} />
         <Route path="/chat" component={ChatScreen} />

--- a/src/screens/ChatScreen.tsx
+++ b/src/screens/ChatScreen.tsx
@@ -4,8 +4,19 @@ import { useAppStore } from '../store'
 import type { ArgType, ChatMessage, ToolDefinition } from '../types'
 
 export default function ChatScreen() {
-  const { settings, messages, tools, addMessage, resetChat, addTool, clearTools, load } =
-    useAppStore()
+  const {
+    settings,
+    messages,
+    tools,
+    addMessage,
+    resetChat,
+    addTool,
+    clearTools,
+    load,
+    lastUsage,
+    totalUsage,
+    addUsage,
+  } = useAppStore()
   const [, navigate] = useLocation()
   const [input, setInput] = useState('')
   const bottomRef = useRef<HTMLDivElement>(null)
@@ -92,6 +103,9 @@ export default function ChatScreen() {
             createdAt: Date.now(),
           })
         }
+      }
+      if (data.usage) {
+        addUsage(data.usage)
       }
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err)
@@ -197,6 +211,31 @@ export default function ChatScreen() {
           >
             Import
           </button>
+          <h3>Stats</h3>
+          {lastUsage && (
+            <div>
+              <strong>Last:</strong>
+              {lastUsage.prompt_tokens !== undefined && (
+                <div>Prompt: {lastUsage.prompt_tokens}</div>
+              )}
+              {lastUsage.completion_tokens !== undefined && (
+                <div>Completion: {lastUsage.completion_tokens}</div>
+              )}
+              {lastUsage.total_tokens !== undefined && <div>Total: {lastUsage.total_tokens}</div>}
+            </div>
+          )}
+          {totalUsage && (
+            <div style="margin-top: 0.5rem;">
+              <strong>Session:</strong>
+              {totalUsage.prompt_tokens !== undefined && (
+                <div>Prompt: {totalUsage.prompt_tokens}</div>
+              )}
+              {totalUsage.completion_tokens !== undefined && (
+                <div>Completion: {totalUsage.completion_tokens}</div>
+              )}
+              {totalUsage.total_tokens !== undefined && <div>Total: {totalUsage.total_tokens}</div>}
+            </div>
+          )}
           <hr />
           <button onClick={() => resetChat()}>Reset Chat</button>
           <button onClick={() => clearTools()}>Clear All Tools</button>

--- a/src/store.test.ts
+++ b/src/store.test.ts
@@ -60,4 +60,32 @@ describe('store', () => {
     ])
     expect(useAppStore.getState().tools).toHaveLength(1)
   })
+
+  it('tracks usage stats', () => {
+    useAppStore.getState().addUsage({ prompt_tokens: 1, completion_tokens: 2, total_tokens: 3 })
+    expect(useAppStore.getState().lastUsage).toEqual({
+      prompt_tokens: 1,
+      completion_tokens: 2,
+      total_tokens: 3,
+    })
+    useAppStore.getState().addUsage({ prompt_tokens: 2, completion_tokens: 3, total_tokens: 5 })
+    expect(useAppStore.getState().totalUsage).toEqual({
+      prompt_tokens: 3,
+      completion_tokens: 5,
+      total_tokens: 8,
+    })
+  })
+
+  it('clears stats when chat is reset', async () => {
+    useAppStore.getState().addUsage({ prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 })
+    await useAppStore.getState().addMessage({
+      role: 'user',
+      content: 'hi',
+      createdAt: 1,
+    })
+    await useAppStore.getState().resetChat()
+    expect(useAppStore.getState().messages).toHaveLength(0)
+    expect(useAppStore.getState().lastUsage).toBeUndefined()
+    expect(useAppStore.getState().totalUsage).toBeUndefined()
+  })
 })

--- a/src/types.ts
+++ b/src/types.ts
@@ -28,3 +28,9 @@ export type ToolDefinition = {
   disabled: boolean
   createdAt: number
 }
+
+export type Usage = {
+  prompt_tokens?: number
+  completion_tokens?: number
+  total_tokens?: number
+}


### PR DESCRIPTION
## Summary
- Configure the router to use Vite's `BASE_URL` so navigation works when the app is deployed under a subdirectory (e.g. GitHub Pages).
- Track and display token usage stats for the last request and entire session in a new sidebar section.
- Resetting the chat now also clears accumulated usage statistics.

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68976e25d7448329b3a1db6293ad4105