### PR TITLE
Improve function handling and UI responsiveness

### DIFF
--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -64,7 +64,12 @@ export default function SettingsScreen() {
           />
         </label>
         {error && <p style="color: var(--del-color);">{error}</p>}
-        <button type="submit">Save & Continue</button>
+        <div role="group">
+          <button type="submit">Save & Continue</button>
+          <button type="button" onClick={() => navigate('/chat')}>
+            Back
+          </button>
+        </div>
       </form>
     </main>
   )


### PR DESCRIPTION
## Summary
- avoid JSON parse errors from function calls and explicitly set `tool_choice` for better LLM decisions
- redesign chat UI: progress bar, table stats, grouped buttons, scrollable tools, improved tool call display
- add back button on settings screen

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_689788ab7cd48329b0055c432c4082ff