### PR TITLE
Enable editing and adding of tools via reusable modal

### DIFF
--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -1,0 +1,9 @@
+import type { ComponentChildren } from 'preact'
+
+export default function Modal({ children }: { children: ComponentChildren }) {
+  return (
+    <div style="position: fixed; inset: 0; background: rgba(0,0,0,0.5); display: flex; align-items: center; justify-content: center;">
+      <div style="background: white; padding: 1rem; width: 90%; max-width: 500px;">{children}</div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- Refactor existing popup into a reusable `Modal` component
- Allow tools to be added or edited through a shared modal form with return type dropdown
- Replace tool list buttons with compact icon links and apply modal for export/import operations

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_6897c84c69588329a6f7c943c43ee59b