### PR TITLE
Add Markdown rendering with sanitization

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,3 +110,9 @@ npm run build
 ```bash
 npm test
 ```
+
+## Markdown Support
+
+Messages accept a safe subset of Markdown. Formatting such as headings, lists,
+bold/italic text, links, code blocks and tables is supported. Raw HTML, scripts
+and iframes are stripped during rendering.

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,10 @@
       "dependencies": {
         "@picocss/pico": "^2.0.6",
         "clsx": "^2.1.0",
+        "dompurify": "^3.2.6",
         "joi": "^17.12.0",
         "localforage": "^1.10.0",
+        "marked": "^16.1.2",
         "preact": "^10.27.0",
         "wouter-preact": "^2.11.0",
         "zustand": "^5.0.5"
@@ -1658,6 +1660,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "7.18.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-7.18.0.tgz",
@@ -2755,6 +2764,15 @@
       },
       "funding": {
         "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/dompurify": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.6.tgz",
+      "integrity": "sha512-/2GogDQlohXPZe6D6NOgQvXLPSYBqIWMnZ8zzOhn09REE4eyAzb+Hed3jhoM9OkuaJ8P6ZGTTVWQKAi8ieIzfQ==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
       }
     },
     "node_modules/domutils": {
@@ -4349,6 +4367,18 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.0"
+      }
+    },
+    "node_modules/marked": {
+      "version": "16.1.2",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-16.1.2.tgz",
+      "integrity": "sha512-rNQt5EvRinalby7zJZu/mB+BvaAY2oz3wCuCjt1RDrWNpS1Pdf9xqMOeC9Hm5adBdcV/3XZPJpG58eT+WBc0XQ==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 20"
       }
     },
     "node_modules/math-intrinsics": {

--- a/package.json
+++ b/package.json
@@ -13,8 +13,10 @@
   "dependencies": {
     "@picocss/pico": "^2.0.6",
     "clsx": "^2.1.0",
+    "dompurify": "^3.2.6",
     "joi": "^17.12.0",
     "localforage": "^1.10.0",
+    "marked": "^16.1.2",
     "preact": "^10.27.0",
     "wouter-preact": "^2.11.0",
     "zustand": "^5.0.5"

--- a/src/components/MarkdownMessage.tsx
+++ b/src/components/MarkdownMessage.tsx
@@ -1,0 +1,41 @@
+import DOMPurify from 'dompurify'
+import { marked } from 'marked'
+
+export default function MarkdownMessage({ source }: { source: string }) {
+  const renderer = new marked.Renderer()
+  // Disable raw HTML entirely
+  renderer.html = () => ''
+  const raw = marked.parse(source, { renderer, mangle: false, headerIds: false })
+  const sanitized = DOMPurify.sanitize(raw, {
+    ALLOWED_TAGS: [
+      'p',
+      'em',
+      'strong',
+      'code',
+      'pre',
+      'ul',
+      'ol',
+      'li',
+      'table',
+      'thead',
+      'tbody',
+      'tr',
+      'th',
+      'td',
+      'blockquote',
+      'a',
+      'h1',
+      'h2',
+      'h3',
+      'h4',
+      'h5',
+      'h6',
+      'hr',
+      'br'
+    ],
+    ALLOWED_ATTR: ['href', 'title'],
+    RETURN_TRUSTED_TYPE: false
+  }) as string
+  return <div class="markdown-message" dangerouslySetInnerHTML={{ __html: sanitized }} />
+}
+

--- a/src/index.css
+++ b/src/index.css
@@ -71,3 +71,17 @@ button:focus-visible {
     background-color: #f9f9f9;
   }
 }
+
+.markdown-message {
+  overflow-wrap: anywhere;
+}
+
+.markdown-message pre,
+.markdown-message ul,
+.markdown-message ol,
+.markdown-message table,
+.markdown-message blockquote {
+  max-width: 100%;
+  overflow-wrap: anywhere;
+}
+

--- a/src/screens/ChatScreen.tsx
+++ b/src/screens/ChatScreen.tsx
@@ -3,6 +3,7 @@ import { useLocation } from 'wouter-preact'
 import { useAppStore } from '../store'
 import type { ArgType, ChatMessage, ToolDefinition, Usage } from '../types'
 import Modal from '../components/Modal'
+import MarkdownMessage from '../components/MarkdownMessage'
 
 type ChatCompletionResponse = {
   error?: { message?: string }
@@ -215,9 +216,17 @@ export default function ChatScreen() {
           <div style="flex: 1; overflow-y: auto;">
             {messages.map((m) => (
               <div key={m.createdAt} style="margin-bottom: 0.25rem;">
-                {m.role === 'user' && <span>👨 {m.content}</span>}
-                {m.role === 'assistant' && <span>🤖 {m.content}</span>}
-                {m.role === 'error' && <span>{m.content}</span>}
+                {m.role === 'user' && (
+                  <>
+                    👨 <MarkdownMessage source={m.content} />
+                  </>
+                )}
+                {m.role === 'assistant' && (
+                  <>
+                    🤖 <MarkdownMessage source={m.content} />
+                  </>
+                )}
+                {m.role === 'error' && <MarkdownMessage source={m.content} />}
                 {m.role === 'reasoning' && (
                   <details>
                     <summary>🤖💭</summary>

--- a/tests/MarkdownMessage.test.tsx
+++ b/tests/MarkdownMessage.test.tsx
@@ -1,0 +1,26 @@
+import { render } from '@testing-library/preact'
+import { describe, it, expect } from 'vitest'
+import MarkdownMessage from '../src/components/MarkdownMessage'
+
+describe('MarkdownMessage', () => {
+  it('renders basic markdown elements', () => {
+    const source = '**bold**\n\n- a\n- b\n\n```\ncode\n```'
+    const { container } = render(<MarkdownMessage source={source} />)
+    expect(container.querySelector('strong')?.textContent).toBe('bold')
+    expect(container.querySelectorAll('li')).toHaveLength(2)
+    expect(container.querySelector('pre code')?.textContent).toBe('code\n')
+  })
+
+  it('strips script tags', () => {
+    const { container } = render(<MarkdownMessage source={'<script>alert(1)</script>'} />)
+    expect(container.querySelector('script')).toBeNull()
+    expect(container.textContent).not.toContain('alert(1)')
+  })
+
+  it('sanitizes javascript urls', () => {
+    const { container } = render(<MarkdownMessage source={'[x](javascript:alert(1))'} />)
+    const link = container.querySelector('a')
+    expect(link).not.toBeNull()
+    expect(link!.getAttribute('href') ?? '').not.toMatch(/^javascript:/i)
+  })
+})


### PR DESCRIPTION
## Summary
- parse and sanitize chat messages using marked and DOMPurify
- render markdown messages and update chat screen
- document markdown support and add tests for sanitization

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_6897d22e478c8329be2753eed91711d8