### PR TITLE
Sanitize chat markdown rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,10 @@ npm install
 npm run dev
 ```
 
+## Markdown Support
+
+Chat messages render a restricted subset of Markdown. Raw HTML, scripts, and iframes are ignored and sanitized. Standard formatting such as emphasis, lists, and code blocks are supported.
+
 ## Build
 
 ```bash

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,10 @@
       "dependencies": {
         "@picocss/pico": "^2.0.6",
         "clsx": "^2.1.0",
+        "dompurify": "^3.2.6",
         "joi": "^17.12.0",
         "localforage": "^1.10.0",
+        "marked": "^16.1.2",
         "preact": "^10.27.0",
         "wouter-preact": "^2.11.0",
         "zustand": "^5.0.5"
@@ -1658,6 +1660,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "7.18.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-7.18.0.tgz",
@@ -2755,6 +2764,15 @@
       },
       "funding": {
         "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/dompurify": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.6.tgz",
+      "integrity": "sha512-/2GogDQlohXPZe6D6NOgQvXLPSYBqIWMnZ8zzOhn09REE4eyAzb+Hed3jhoM9OkuaJ8P6ZGTTVWQKAi8ieIzfQ==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
       }
     },
     "node_modules/domutils": {
@@ -4349,6 +4367,18 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.0"
+      }
+    },
+    "node_modules/marked": {
+      "version": "16.1.2",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-16.1.2.tgz",
+      "integrity": "sha512-rNQt5EvRinalby7zJZu/mB+BvaAY2oz3wCuCjt1RDrWNpS1Pdf9xqMOeC9Hm5adBdcV/3XZPJpG58eT+WBc0XQ==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 20"
       }
     },
     "node_modules/math-intrinsics": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,9 @@
     "localforage": "^1.10.0",
     "preact": "^10.27.0",
     "wouter-preact": "^2.11.0",
-    "zustand": "^5.0.5"
+    "zustand": "^5.0.5",
+    "marked": "^16.1.2",
+    "dompurify": "^3.2.6"
   },
   "devDependencies": {
     "@preact/preset-vite": "^2.10.2",

--- a/src/components/MarkdownMessage.tsx
+++ b/src/components/MarkdownMessage.tsx
@@ -1,0 +1,17 @@
+import { marked } from 'marked'
+import DOMPurify from 'dompurify'
+
+interface MarkdownMessageProps {
+  source: string
+}
+
+export default function MarkdownMessage({ source }: MarkdownMessageProps) {
+  const escaped = source.replace(/</g, '&lt;').replace(/>/g, '&gt;')
+  const unsafe = marked.parse(escaped, {
+    mangle: false,
+    headerIds: false,
+    breaks: true,
+  })
+  const html = DOMPurify.sanitize(unsafe)
+  return <div class="markdown-message" dangerouslySetInnerHTML={{ __html: html }} />
+}

--- a/src/index.css
+++ b/src/index.css
@@ -71,3 +71,20 @@ button:focus-visible {
     background-color: #f9f9f9;
   }
 }
+
+.markdown-message {
+  overflow-wrap: anywhere;
+  max-width: 100%;
+}
+
+.markdown-message pre,
+.markdown-message ul,
+.markdown-message ol,
+.markdown-message table {
+  overflow-wrap: anywhere;
+  max-width: 100%;
+}
+
+.markdown-message pre {
+  white-space: pre-wrap;
+}

--- a/src/screens/ChatScreen.tsx
+++ b/src/screens/ChatScreen.tsx
@@ -3,6 +3,7 @@ import { useLocation } from 'wouter-preact'
 import { useAppStore } from '../store'
 import type { ArgType, ChatMessage, ToolDefinition, Usage } from '../types'
 import Modal from '../components/Modal'
+import MarkdownMessage from '../components/MarkdownMessage'
 
 type ChatCompletionResponse = {
   error?: { message?: string }
@@ -214,10 +215,23 @@ export default function ChatScreen() {
         <div style="flex: 0 0 70%; display: flex; flex-direction: column;">
           <div style="flex: 1; overflow-y: auto;">
             {messages.map((m) => (
-              <div key={m.createdAt} style="margin-bottom: 0.25rem;">
-                {m.role === 'user' && <span>👨 {m.content}</span>}
-                {m.role === 'assistant' && <span>🤖 {m.content}</span>}
-                {m.role === 'error' && <span>{m.content}</span>}
+              <div
+                key={m.createdAt}
+                style="margin-bottom: 0.25rem; display: flex; gap: 0.25rem; align-items: flex-start;"
+              >
+                {m.role === 'user' && (
+                  <>
+                    <span>👨</span>
+                    <MarkdownMessage source={m.content} />
+                  </>
+                )}
+                {m.role === 'assistant' && (
+                  <>
+                    <span>🤖</span>
+                    <MarkdownMessage source={m.content} />
+                  </>
+                )}
+                {m.role === 'error' && <MarkdownMessage source={m.content} />}
                 {m.role === 'reasoning' && (
                   <details>
                     <summary>🤖💭</summary>

--- a/tests/MarkdownMessage.test.tsx
+++ b/tests/MarkdownMessage.test.tsx
@@ -1,0 +1,20 @@
+import { render } from '@testing-library/preact'
+import { describe, it, expect } from 'vitest'
+import MarkdownMessage from '../src/components/MarkdownMessage'
+
+describe('MarkdownMessage', () => {
+  it('renders standard markdown', () => {
+    const md = '**bold**\n\n- one\n- two\n\n```\ncode\n```'
+    const { container } = render(<MarkdownMessage source={md} />)
+    expect(container.querySelector('strong')?.textContent).toBe('bold')
+    expect(container.querySelectorAll('li')).toHaveLength(2)
+    expect(container.querySelector('pre code')?.textContent).toBe('code\n')
+  })
+
+  it('sanitizes malicious content', () => {
+    const md = '<script>alert(1)</script>[x](javascript:alert(1))'
+    const { container } = render(<MarkdownMessage source={md} />)
+    expect(container.querySelector('script')).toBeNull()
+    expect(container.innerHTML).not.toContain('javascript:')
+  })
+})


### PR DESCRIPTION
## Summary
- Parse chat messages as Markdown and sanitize HTML before rendering
- Replace span-based message rendering with MarkdownMessage component and wrap long blocks
- Document safe Markdown subset and cover behavior with unit tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6897d8f68e908329a7d11b5a054d689c