### PR TITLE
fix: update marked options for new marked version

### DIFF
--- a/src/components/MarkdownMessage.tsx
+++ b/src/components/MarkdownMessage.tsx
@@ -7,10 +7,12 @@ interface MarkdownMessageProps {
 
 export default function MarkdownMessage({ source }: MarkdownMessageProps) {
   const escaped = source.replace(/</g, '&lt;').replace(/>/g, '&gt;')
+  // newer versions of `marked` removed the `mangle` and `headerIds` options;
+  // passing them now results in a type error. These features are disabled
+  // by default, so we only need to enable line breaks explicitly.
   const unsafe = marked.parse(escaped, {
-    mangle: false,
-    headerIds: false,
     breaks: true,
+    async: false,
   })
   const html = DOMPurify.sanitize(unsafe)
   return <div class="markdown-message" dangerouslySetInnerHTML={{ __html: html }} />


### PR DESCRIPTION
## Summary
- remove deprecated `mangle` and `headerIds` options from marked usage
- ensure `marked.parse` returns string by setting `async: false`

## Testing
- `npm test`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_6897e07fb4d4832988410a0d355a13da