### PR TITLE
fix: include tool results in chat requests

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -11,6 +11,7 @@ export type ChatMessage =
   | { role: 'reasoning'; content: string; createdAt: number }
   | {
       role: 'tool'
+      toolCallId: string
       toolName: string
       args: Record<string, unknown>
       result?: unknown


### PR DESCRIPTION
## Summary
- ensure tool call outputs are returned to the model by including tool messages with call IDs
- extend ChatMessage type with toolCallId and update ChatScreen to forward results

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_6897e92be16c8329866c7b486852f7dc