### PR TITLE
Preserve assistant tool calls

### DIFF
--- a/src/screens/ChatScreen.tsx
+++ b/src/screens/ChatScreen.tsx
@@ -86,8 +86,8 @@ export default function ChatScreen() {
           }
           const content = data.choices?.[0]?.message?.content?.trim() ?? ''
           const toolCalls = data.choices?.[0]?.message?.tool_calls
-          if (content || !toolCalls) {
-            await addMessage({ role: 'assistant', content, createdAt: Date.now() })
+          if (content || toolCalls) {
+            await addMessage({ role: 'assistant', content, toolCalls, createdAt: Date.now() })
           }
           if (data.usage) {
             addUsage(data.usage)

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,7 +6,12 @@ export type Settings = {
 
 export type ChatMessage =
   | { role: 'user'; content: string; createdAt: number }
-  | { role: 'assistant'; content: string; createdAt: number }
+  | {
+      role: 'assistant'
+      content: string
+      createdAt: number
+      toolCalls?: { id: string; function: { name: string; arguments?: string } }[]
+    }
   | { role: 'error'; content: string; createdAt: number }
   | { role: 'reasoning'; content: string; createdAt: number }
   | {


### PR DESCRIPTION
## Summary
- store assistant tool call metadata
- include `tool_calls` when sending messages to API
- record assistant tool calls in chat loop and test

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68980e639910832992069be174c8bd81