### PR TITLE
Fix usage cost tracking and precision

### DIFF
--- a/src/components/StatsTable.tsx
+++ b/src/components/StatsTable.tsx
@@ -24,10 +24,10 @@ export default function StatsTable({ lastUsage, totalUsage }: Props) {
           <tr>
             <th>Prompt</th>
             <td>{lastUsage?.prompt_tokens ?? '-'}</td>
-            <td>{lastUsage?.prompt_cost !== undefined ? lastUsage.prompt_cost.toFixed(4) : '-'}</td>
+            <td>{lastUsage?.prompt_cost !== undefined ? lastUsage.prompt_cost.toFixed(6) : '-'}</td>
             <td>{totalUsage?.prompt_tokens ?? '-'}</td>
             <td>
-              {totalUsage?.prompt_cost !== undefined ? totalUsage.prompt_cost.toFixed(4) : '-'}
+              {totalUsage?.prompt_cost !== undefined ? totalUsage.prompt_cost.toFixed(6) : '-'}
             </td>
           </tr>
           <tr>
@@ -35,22 +35,22 @@ export default function StatsTable({ lastUsage, totalUsage }: Props) {
             <td>{lastUsage?.completion_tokens ?? '-'}</td>
             <td>
               {lastUsage?.completion_cost !== undefined
-                ? lastUsage.completion_cost.toFixed(4)
+                ? lastUsage.completion_cost.toFixed(6)
                 : '-'}
             </td>
             <td>{totalUsage?.completion_tokens ?? '-'}</td>
             <td>
               {totalUsage?.completion_cost !== undefined
-                ? totalUsage.completion_cost.toFixed(4)
+                ? totalUsage.completion_cost.toFixed(6)
                 : '-'}
             </td>
           </tr>
           <tr>
             <th>Total</th>
             <td>{lastUsage?.total_tokens ?? '-'}</td>
-            <td>{lastUsage?.total_cost !== undefined ? lastUsage.total_cost.toFixed(4) : '-'}</td>
+            <td>{lastUsage?.total_cost !== undefined ? lastUsage.total_cost.toFixed(6) : '-'}</td>
             <td>{totalUsage?.total_tokens ?? '-'}</td>
-            <td>{totalUsage?.total_cost !== undefined ? totalUsage.total_cost.toFixed(4) : '-'}</td>
+            <td>{totalUsage?.total_cost !== undefined ? totalUsage.total_cost.toFixed(6) : '-'}</td>
           </tr>
         </tbody>
       </table>

--- a/src/store.test.ts
+++ b/src/store.test.ts
@@ -97,6 +97,17 @@ describe('store', () => {
     expect(total?.total_cost).toBeCloseTo(0.8)
   })
 
+  it('maps cost to total_cost', () => {
+    useAppStore.getState().addUsage({
+      prompt_tokens: 1,
+      completion_tokens: 1,
+      total_tokens: 2,
+      cost: 0.123456,
+    })
+    expect(useAppStore.getState().lastUsage?.total_cost).toBeCloseTo(0.123456)
+    expect(useAppStore.getState().totalUsage?.total_cost).toBeCloseTo(0.123456)
+  })
+
   it('removes messages', async () => {
     await useAppStore.getState().addMessage({
       role: 'user',

--- a/src/store.ts
+++ b/src/store.ts
@@ -98,15 +98,19 @@ export const useAppStore = create<AppState>((set, get) => ({
   },
   addUsage(u) {
     const prev = get().totalUsage ?? {}
+    const totalCost = u.total_cost ?? u.cost ?? 0
     set({
-      lastUsage: u,
+      lastUsage: {
+        ...u,
+        ...(u.cost !== undefined && u.total_cost === undefined ? { total_cost: u.cost } : {}),
+      },
       totalUsage: {
         prompt_tokens: (prev.prompt_tokens ?? 0) + (u.prompt_tokens ?? 0),
         completion_tokens: (prev.completion_tokens ?? 0) + (u.completion_tokens ?? 0),
         total_tokens: (prev.total_tokens ?? 0) + (u.total_tokens ?? 0),
         prompt_cost: (prev.prompt_cost ?? 0) + (u.prompt_cost ?? 0),
         completion_cost: (prev.completion_cost ?? 0) + (u.completion_cost ?? 0),
-        total_cost: (prev.total_cost ?? 0) + (u.total_cost ?? 0),
+        total_cost: (prev.total_cost ?? 0) + totalCost,
       },
     })
   },

--- a/src/types.ts
+++ b/src/types.ts
@@ -43,6 +43,7 @@ export type Usage = {
   prompt_cost?: number
   completion_cost?: number
   total_cost?: number
+  cost?: number
 }
 
 export type ChatCompletionResponse = {

--- a/tests/StatsTable.test.tsx
+++ b/tests/StatsTable.test.tsx
@@ -1,7 +1,12 @@
 import { render } from '@testing-library/preact'
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, beforeEach } from 'vitest'
 import StatsTable from '../src/components/StatsTable'
 import type { Usage } from '../src/types'
+import { useAppStore } from '../src/store'
+
+beforeEach(async () => {
+  await useAppStore.getState().resetChat()
+})
 
 describe('StatsTable', () => {
   it('renders usage values', () => {
@@ -23,8 +28,19 @@ describe('StatsTable', () => {
     }
     const { getByText } = render(<StatsTable lastUsage={last} totalUsage={total} />)
     expect(getByText('1')).toBeTruthy()
-    expect(getByText('0.1000')).toBeTruthy()
-    expect(getByText('0.9000')).toBeTruthy()
+    expect(getByText('0.100000')).toBeTruthy()
+    expect(getByText('0.900000')).toBeTruthy()
+  })
+
+  it('sums tiny costs accurately', () => {
+    const { addUsage } = useAppStore.getState()
+    addUsage({ cost: 0.000001 })
+    addUsage({ cost: 0.000001 })
+    addUsage({ cost: 0.000001 })
+    const { lastUsage, totalUsage } = useAppStore.getState()
+    const { getByText } = render(<StatsTable lastUsage={lastUsage} totalUsage={totalUsage} />)
+    expect(getByText('0.000001')).toBeTruthy()
+    expect(getByText('0.000003')).toBeTruthy()
   })
 
   it('renders nothing without usage', () => {


### PR DESCRIPTION
## Summary
- handle `usage.cost` from API when tracking usage
- display costs with 6 decimal precision in stats table
- add tests for cost mapping and tiny-cost aggregation

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_6898135c4ecc8329a528224acbf9cbe4