### PR TITLE
Simplify stats table cost display

### DIFF
--- a/src/components/StatsTable.tsx
+++ b/src/components/StatsTable.tsx
@@ -15,41 +15,28 @@ export default function StatsTable({ lastUsage, totalUsage }: Props) {
           <tr>
             <th></th>
             <th>Last</th>
-            <th>$</th>
             <th>Total</th>
-            <th>$</th>
           </tr>
         </thead>
         <tbody>
           <tr>
             <th>Prompt</th>
             <td>{lastUsage?.prompt_tokens ?? '-'}</td>
-            <td>{lastUsage?.prompt_cost !== undefined ? lastUsage.prompt_cost.toFixed(6) : '-'}</td>
             <td>{totalUsage?.prompt_tokens ?? '-'}</td>
-            <td>
-              {totalUsage?.prompt_cost !== undefined ? totalUsage.prompt_cost.toFixed(6) : '-'}
-            </td>
           </tr>
           <tr>
             <th>Completion</th>
             <td>{lastUsage?.completion_tokens ?? '-'}</td>
-            <td>
-              {lastUsage?.completion_cost !== undefined
-                ? lastUsage.completion_cost.toFixed(6)
-                : '-'}
-            </td>
             <td>{totalUsage?.completion_tokens ?? '-'}</td>
-            <td>
-              {totalUsage?.completion_cost !== undefined
-                ? totalUsage.completion_cost.toFixed(6)
-                : '-'}
-            </td>
           </tr>
           <tr>
             <th>Total</th>
             <td>{lastUsage?.total_tokens ?? '-'}</td>
-            <td>{lastUsage?.total_cost !== undefined ? lastUsage.total_cost.toFixed(6) : '-'}</td>
             <td>{totalUsage?.total_tokens ?? '-'}</td>
+          </tr>
+          <tr>
+            <th>Cost</th>
+            <td>{lastUsage?.total_cost !== undefined ? lastUsage.total_cost.toFixed(6) : '-'}</td>
             <td>{totalUsage?.total_cost !== undefined ? totalUsage.total_cost.toFixed(6) : '-'}</td>
           </tr>
         </tbody>

--- a/tests/StatsTable.test.tsx
+++ b/tests/StatsTable.test.tsx
@@ -28,7 +28,7 @@ describe('StatsTable', () => {
     }
     const { getByText } = render(<StatsTable lastUsage={last} totalUsage={total} />)
     expect(getByText('1')).toBeTruthy()
-    expect(getByText('0.100000')).toBeTruthy()
+    expect(getByText('0.300000')).toBeTruthy()
     expect(getByText('0.900000')).toBeTruthy()
   })
 


### PR DESCRIPTION
## Summary
- add dedicated "Cost" row to stats table showing last and total costs
- update StatsTable tests for new layout and cost aggregation

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_689819811d688329a7df3ccb4498d04b