### PR TITLE
Add streaming support with live assistant previews

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,10 +126,6 @@ npm install
 npm run dev
 ```
 
-## Markdown Support
-
-Chat messages render a restricted subset of Markdown. Raw HTML, scripts, and iframes are ignored and sanitized. Standard formatting such as emphasis, lists, and code blocks are supported.
-
 ## Build
 
 ```bash

--- a/src/components/ChatMessages.tsx
+++ b/src/components/ChatMessages.tsx
@@ -4,11 +4,17 @@ import type { ChatMessage } from '../types'
 
 interface Props {
   messages: ChatMessage[]
+  pendingAssistant?: string
   removeMessage: (createdAt: number) => Promise<void>
   bottomRef: RefObject<HTMLDivElement>
 }
 
-export default function ChatMessages({ messages, removeMessage, bottomRef }: Props) {
+export default function ChatMessages({
+  messages,
+  pendingAssistant,
+  removeMessage,
+  bottomRef,
+}: Props) {
   return (
     <div style="flex: 1; overflow-y: auto;">
       {messages.map((m) => (
@@ -53,6 +59,14 @@ export default function ChatMessages({ messages, removeMessage, bottomRef }: Pro
           </a>
         </div>
       ))}
+      {pendingAssistant && (
+        <div
+          style="margin-bottom: 0.25rem; display: flex; gap: 0.25rem; align-items: flex-start;"
+        >
+          <span>🤖</span>
+          <MarkdownMessage source={pendingAssistant} />
+        </div>
+      )}
       <div ref={bottomRef} />
     </div>
   )

--- a/src/components/ChatMessages.tsx
+++ b/src/components/ChatMessages.tsx
@@ -60,9 +60,7 @@ export default function ChatMessages({
         </div>
       ))}
       {pendingAssistant && (
-        <div
-          style="margin-bottom: 0.25rem; display: flex; gap: 0.25rem; align-items: flex-start;"
-        >
+        <div style="margin-bottom: 0.25rem; display: flex; gap: 0.25rem; align-items: flex-start;">
           <span>🤖</span>
           <MarkdownMessage source={pendingAssistant} />
         </div>

--- a/src/services/llm.ts
+++ b/src/services/llm.ts
@@ -5,6 +5,7 @@ export async function requestChatCompletion(
   messages: ChatMessage[],
   tools: ToolDefinition[],
   systemPrompt: string,
+  onChunk?: (token: string) => void,
 ): Promise<ChatCompletionResponse> {
   type ApiMessage =
     | {
@@ -59,6 +60,7 @@ export async function requestChatCompletion(
     messages: apiMessages,
     tool_choice: activeTools.length > 0 ? 'auto' : 'none',
     usage: { include: true },
+    ...(onChunk ? { stream: true } : {}),
   }
   if (activeTools.length > 0) payload.tools = activeTools
 
@@ -70,11 +72,83 @@ export async function requestChatCompletion(
     },
     body: JSON.stringify(payload),
   })
-  const data = (await res.json()) as ChatCompletionResponse
-  if (!res.ok || data.error) {
-    throw new Error(data.error?.message ?? `${res.status} ${res.statusText}`)
+
+  if (!onChunk) {
+    const data = (await res.json()) as ChatCompletionResponse
+    if (!res.ok || data.error) {
+      throw new Error(data.error?.message ?? `${res.status} ${res.statusText}`)
+    }
+    return data
   }
-  return data
+
+  if (!res.ok) {
+    throw new Error(`${res.status} ${res.statusText}`)
+  }
+
+  const reader = res.body?.getReader()
+  if (!reader) throw new Error('No response body')
+  const decoder = new TextDecoder()
+  let buffer = ''
+  let content = ''
+  let toolCalls: { id: string; function: { name: string; arguments?: string } }[] | undefined
+  let usage: ChatCompletionResponse['usage']
+
+  for (;;) {
+    const { value, done } = await reader.read()
+    if (done) break
+    buffer += decoder.decode(value)
+    const lines = buffer.split('\n')
+    buffer = lines.pop() ?? ''
+    for (const line of lines) {
+      const trimmed = line.trim()
+      if (!trimmed.startsWith('data:')) continue
+      const dataStr = trimmed.slice(5).trim()
+      if (dataStr === '[DONE]') {
+        buffer = ''
+        continue
+      }
+      const json = JSON.parse(dataStr)
+      const delta = json.choices?.[0]?.delta
+      if (delta?.content) {
+        content += delta.content
+        onChunk(delta.content)
+      }
+      if (delta?.tool_calls) {
+        toolCalls = toolCalls ?? []
+        for (const tc of delta.tool_calls) {
+          const index = tc.index ?? toolCalls.length
+          const existing = toolCalls[index] ?? {
+            id: tc.id ?? '',
+            function: { name: tc.function?.name ?? '', arguments: '' },
+          }
+          if (tc.id) existing.id = tc.id
+          if (tc.function?.name) existing.function.name = tc.function.name
+          if (tc.function?.arguments)
+            existing.function.arguments =
+              (existing.function.arguments ?? '') + tc.function.arguments
+          toolCalls[index] = existing
+        }
+      }
+      if (json.choices?.[0]?.message?.tool_calls) {
+        toolCalls = json.choices[0].message.tool_calls
+      }
+      if (json.usage) {
+        usage = json.usage
+      }
+    }
+  }
+
+  return {
+    choices: [
+      {
+        message: {
+          content,
+          ...(toolCalls ? { tool_calls: toolCalls } : {}),
+        },
+      },
+    ],
+    ...(usage ? { usage } : {}),
+  }
 }
 
 export type { ChatCompletionResponse } from '../types'

--- a/tests/ChatScreen.test.tsx
+++ b/tests/ChatScreen.test.tsx
@@ -1,0 +1,121 @@
+import { render, fireEvent, waitFor } from '@testing-library/preact'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+vi.mock('../src/store', () => {
+  const state: any = {
+    settings: undefined,
+    messages: [],
+    tools: [],
+    lastUsage: undefined,
+    totalUsage: undefined,
+    systemPrompt: '',
+    async addMessage(m: any) {
+      state.messages.push(m)
+    },
+    async removeMessage(createdAt: number) {
+      state.messages = state.messages.filter((m: any) => m.createdAt !== createdAt)
+    },
+    async resetChat() {},
+    async addTool() {},
+    async clearTools() {
+      state.tools = []
+    },
+    addUsage(u: any) {
+      state.lastUsage = u
+      state.totalUsage = u
+    },
+    async setSystemPrompt(p: string) {
+      state.systemPrompt = p
+    },
+  }
+  const useAppStore = () => state
+  ;(useAppStore as any).getState = () => state
+  ;(useAppStore as any).setState = (s: any) => Object.assign(state, s)
+  return { useAppStore }
+})
+
+import ChatScreen from '../src/screens/ChatScreen'
+import { useAppStore } from '../src/store'
+
+(Element.prototype as any).scrollIntoView = vi.fn()
+
+vi.mock('localforage', () => ({
+  default: {
+    setItem: vi.fn(async () => {}),
+    getItem: vi.fn(async () => null),
+    removeItem: vi.fn(async () => {}),
+  },
+}))
+
+vi.mock('wouter-preact', () => ({
+  useLocation: () => ['', vi.fn()],
+}))
+
+describe('ChatScreen streaming', () => {
+  const fetchMock = vi.fn()
+
+  beforeEach(() => {
+    fetchMock.mockReset()
+    vi.stubGlobal('fetch', fetchMock)
+    useAppStore.setState({
+      settings: { apiBaseUrl: 'https://api', model: 'gpt' },
+      messages: [],
+      tools: [],
+      lastUsage: undefined,
+      totalUsage: undefined,
+      systemPrompt: '',
+    })
+  })
+
+  it('shows streaming assistant before final message and updates stats', async () => {
+    const encoder = new TextEncoder()
+    let controller: ReadableStreamDefaultController<Uint8Array>
+    fetchMock.mockResolvedValue({
+      ok: true,
+      body: new ReadableStream({
+        start(c) {
+          controller = c
+          c.enqueue(
+            encoder.encode('data: {"choices":[{"delta":{"content":"hel"}}]}\n\n'),
+          )
+        },
+      }),
+    })
+
+    const { getAllByRole, getByText, queryAllByText, getAllByText } = render(<ChatScreen />)
+    const input = getAllByRole('textbox')[0] as HTMLInputElement
+    await fireEvent.input(input, { target: { value: 'hi' } })
+    await fireEvent.keyDown(input, { key: 'Enter' })
+
+    await waitFor(() => {
+      expect(getByText('hel')).toBeTruthy()
+    })
+    expect(queryAllByText('x')).toHaveLength(1)
+
+    controller.enqueue(
+      encoder.encode('data: {"choices":[{"delta":{"content":"lo"}}]}\n\n'),
+    )
+    await waitFor(() => {
+      expect(getByText('hello')).toBeTruthy()
+    })
+    expect(queryAllByText('x')).toHaveLength(1)
+
+    controller.enqueue(
+      encoder.encode(
+        'data: {"choices":[{"message":{}}],"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}}\n\n',
+      ),
+    )
+    controller.enqueue(encoder.encode('data: [DONE]\n\n'))
+    controller.close()
+
+    await waitFor(() => {
+      expect(queryAllByText('x')).toHaveLength(2)
+    })
+    await waitFor(() => {
+      expect(getByText('Stats')).toBeTruthy()
+    })
+    await waitFor(() => {
+      expect(getAllByText('2').length).toBeGreaterThan(0)
+    })
+  })
+})

--- a/tests/llm.test.ts
+++ b/tests/llm.test.ts
@@ -93,6 +93,37 @@ describe('requestChatCompletion', () => {
     })
   })
 
+  it('streams tokens and returns usage', async () => {
+    const encoder = new TextEncoder()
+    fetchMock.mockResolvedValue({
+      ok: true,
+      body: new ReadableStream({
+        start(controller) {
+          controller.enqueue(
+            encoder.encode('data: {"choices":[{"delta":{"content":"hel"}}]}\n\n'),
+          )
+          controller.enqueue(
+            encoder.encode('data: {"choices":[{"delta":{"content":"lo"}}]}\n\n'),
+          )
+          controller.enqueue(
+            encoder.encode(
+              'data: {"choices":[{"message":{"tool_calls":[{"id":"t","function":{"name":"foo"}}]}}],"usage":{"total_tokens":3}}\n\n',
+            ),
+          )
+          controller.enqueue(encoder.encode('data: [DONE]\n\n'))
+          controller.close()
+        },
+      }),
+    })
+    const chunks: string[] = []
+    const res = await requestChatCompletion(settings, [], [], '', (c) => chunks.push(c))
+    expect(chunks).toEqual(['hel', 'lo'])
+    expect(res.choices?.[0]?.message?.content).toBe('hello')
+    expect(res.usage?.total_tokens).toBe(3)
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body as string)
+    expect(body.stream).toBe(true)
+  })
+
   it('throws on API error', async () => {
     fetchMock.mockResolvedValue({
       ok: false,

--- a/tests/llm.test.ts
+++ b/tests/llm.test.ts
@@ -99,12 +99,8 @@ describe('requestChatCompletion', () => {
       ok: true,
       body: new ReadableStream({
         start(controller) {
-          controller.enqueue(
-            encoder.encode('data: {"choices":[{"delta":{"content":"hel"}}]}\n\n'),
-          )
-          controller.enqueue(
-            encoder.encode('data: {"choices":[{"delta":{"content":"lo"}}]}\n\n'),
-          )
+          controller.enqueue(encoder.encode('data: {"choices":[{"delta":{"content":"hel"}}]}\n\n'))
+          controller.enqueue(encoder.encode('data: {"choices":[{"delta":{"content":"lo"}}]}\n\n'))
           controller.enqueue(
             encoder.encode(
               'data: {"choices":[{"message":{"tool_calls":[{"id":"t","function":{"name":"foo"}}]}}],"usage":{"total_tokens":3}}\n\n',


### PR DESCRIPTION
## Summary
- enable optional `onChunk` streaming in LLM service
- stream assistant replies in chat UI with pending preview
- adjust ChatMessages and remove Markdown docs
- add unit and integration tests for streaming behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6899270e79e483298b77017d2a5f8171